### PR TITLE
Use API_BASE_URL for dashboard placeholders

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -20,6 +20,7 @@ import {
 import { LineChart, Line, AreaChart, Area, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts'
 import { useAuth } from '../contexts/AuthContext'
 import { Button } from '@/components/ui/button'
+import API_BASE_URL from '../config/api'
 
 // Mock data
 const marketData = [
@@ -43,7 +44,7 @@ const recentProperties = [
     discount: 32,
     financing: true,
     aiScore: 9.2,
-    image: '/api/placeholder/300/200'
+    image: `${API_BASE_URL}/placeholder/300/200`
   },
   {
     id: 2,
@@ -56,7 +57,7 @@ const recentProperties = [
     discount: 30,
     financing: false,
     aiScore: 8.7,
-    image: '/api/placeholder/300/200'
+    image: `${API_BASE_URL}/placeholder/300/200`
   },
   {
     id: 3,
@@ -69,7 +70,7 @@ const recentProperties = [
     discount: 30,
     financing: true,
     aiScore: 8.9,
-    image: '/api/placeholder/300/200'
+    image: `${API_BASE_URL}/placeholder/300/200`
   }
 ]
 


### PR DESCRIPTION
## Summary
- import API_BASE_URL in dashboard
- use configured API base URL for recent property placeholder images

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_688ec2ac56e8832a94446cdfacddcecf