### PR TITLE
feat: implement login form

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,15 +1,121 @@
-export default function Login() {
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Label } from '@/components/ui/label'
+import { Eye, EyeOff } from 'lucide-react'
+
+const Login = () => {
+  const navigate = useNavigate()
+  const { login } = useAuth()
+  const [formData, setFormData] = useState({ email: '', password: '' })
+  const [errors, setErrors] = useState({})
+  const [apiError, setApiError] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+    setErrors((prev) => ({ ...prev, [name]: '' }))
+    setApiError('')
+  }
+
+  const validate = () => {
+    const newErrors = {}
+    if (!formData.email) {
+      newErrors.email = 'Email é obrigatório'
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+      newErrors.email = 'Email inválido'
+    }
+
+    if (!formData.password) {
+      newErrors.password = 'Senha é obrigatória'
+    } else if (formData.password.length < 6) {
+      newErrors.password = 'A senha deve ter no mínimo 6 caracteres'
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!validate()) return
+
+    setIsLoading(true)
+    const { success, error } = await login(formData.email, formData.password)
+    setIsLoading(false)
+
+    if (success) {
+      navigate('/dashboard')
+    } else {
+      setApiError(error || 'Erro ao fazer login')
+    }
+  }
+
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-      <div className="max-w-md w-full bg-white rounded-lg shadow-md p-8">
-        <h1 className="text-2xl font-bold text-gray-900 text-center mb-8">
-          Entrar
-        </h1>
-        <p className="text-gray-600 text-center">
-          Página de login em desenvolvimento...
-        </p>
-      </div>
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Entrar</CardTitle>
+          <CardDescription>Acesse sua conta</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {apiError && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertDescription>{apiError}</AlertDescription>
+            </Alert>
+          )}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                name="email"
+                type="email"
+                value={formData.email}
+                onChange={handleChange}
+                aria-invalid={!!errors.email}
+              />
+              {errors.email && <p className="text-sm text-destructive">{errors.email}</p>}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Senha</Label>
+              <div className="relative">
+                <Input
+                  id="password"
+                  name="password"
+                  type={showPassword ? 'text' : 'password'}
+                  value={formData.password}
+                  onChange={handleChange}
+                  aria-invalid={!!errors.password}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-0 top-0 h-full px-3 py-0 text-muted-foreground"
+                  onClick={() => setShowPassword((prev) => !prev)}
+                  tabIndex={-1}
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </Button>
+              </div>
+              {errors.password && <p className="text-sm text-destructive">{errors.password}</p>}
+            </div>
+            <Button type="submit" className="w-full" disabled={isLoading}>
+              {isLoading ? 'Entrando...' : 'Entrar'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
     </div>
   )
 }
+
+export default Login
 


### PR DESCRIPTION
## Summary
- add fully functional login form with client-side validation and password toggle
- handle API login, loading state, and navigation on success

## Testing
- `cd frontend && pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ecc6ad964832a8917ddae5f778969