### PR TITLE
Refactor auth context and adjust feature helpers

### DIFF
--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -84,7 +84,34 @@ const adminItems = [
 
 export default function Sidebar({ open, setOpen, isAdmin = false }) {
   const location = useLocation()
-  const { hasFeature, user } = useAuth()
+  const { user } = useAuth()
+
+  const hasFeature = (feature) => {
+    const planFeatures = {
+      basic: ['property_search', 'basic_filters', 'favorites'],
+      pro: [
+        'property_search',
+        'basic_filters',
+        'favorites',
+        'advanced_filters',
+        'market_analysis',
+        'alerts'
+      ],
+      premium: [
+        'property_search',
+        'basic_filters',
+        'favorites',
+        'advanced_filters',
+        'market_analysis',
+        'alerts',
+        'ai_analysis',
+        'auction_strategies',
+        'priority_support'
+      ]
+    }
+    const plan = user?.subscription?.plan?.name?.toLowerCase() || 'basic'
+    return planFeatures[plan]?.includes(feature) || false
+  }
 
   const isActive = (href) => {
     return location.pathname === href || location.pathname.startsWith(href + '/')

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,273 +1,135 @@
-import { createContext, useContext, useReducer, useEffect } from 'react'
+import { createContext, useContext, useState, useEffect } from 'react'
 import API_BASE_URL from '../config/api'
 
 const AuthContext = createContext()
 
-// Actions
-const AUTH_ACTIONS = {
-  LOGIN_START: 'LOGIN_START',
-  LOGIN_SUCCESS: 'LOGIN_SUCCESS',
-  LOGIN_FAILURE: 'LOGIN_FAILURE',
-  LOGOUT: 'LOGOUT',
-  UPDATE_USER: 'UPDATE_USER',
-  SET_LOADING: 'SET_LOADING'
-}
-
-// Initial state
-const initialState = {
-  user: null,
-  isAuthenticated: false,
-  loading: true,
-  error: null,
-  subscription: null
-}
-
-// Reducer
-function authReducer(state, action) {
-  switch (action.type) {
-    case AUTH_ACTIONS.LOGIN_START:
-      return {
-        ...state,
-        loading: true,
-        error: null
-      }
-    
-    case AUTH_ACTIONS.LOGIN_SUCCESS:
-      return {
-        ...state,
-        user: action.payload.user,
-        subscription: action.payload.subscription,
-        isAuthenticated: true,
-        loading: false,
-        error: null
-      }
-    
-    case AUTH_ACTIONS.LOGIN_FAILURE:
-      return {
-        ...state,
-        user: null,
-        isAuthenticated: false,
-        loading: false,
-        error: action.payload
-      }
-    
-    case AUTH_ACTIONS.LOGOUT:
-      return {
-        ...state,
-        user: null,
-        subscription: null,
-        isAuthenticated: false,
-        loading: false,
-        error: null
-      }
-    
-    case AUTH_ACTIONS.UPDATE_USER:
-      return {
-        ...state,
-        user: { ...state.user, ...action.payload }
-      }
-    
-    case AUTH_ACTIONS.SET_LOADING:
-      return {
-        ...state,
-        loading: action.payload
-      }
-    
-    default:
-      return state
-  }
-}
-
-// Provider component
 export function AuthProvider({ children }) {
-  const [state, dispatch] = useReducer(authReducer, initialState)
+  const [user, setUser] = useState(null)
+  const [token, setToken] = useState(null)
+  const [loading, setLoading] = useState(true)
 
-  // Check for existing session on mount
   useEffect(() => {
-    checkAuthStatus()
+    const storedToken = localStorage.getItem('auth_token')
+    if (storedToken) {
+      setToken(storedToken)
+      validateToken(storedToken)
+    } else {
+      setLoading(false)
+    }
   }, [])
 
-  const checkAuthStatus = async () => {
+  const validateToken = async (jwt) => {
     try {
-      const token = localStorage.getItem('auth_token')
-      if (!token) {
-        dispatch({ type: AUTH_ACTIONS.SET_LOADING, payload: false })
-        return
-      }
-
-      // Validate token with backend
-      const response = await fetch(`${API_BASE_URL}/auth/me`, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        }
+      const res = await fetch(`${API_BASE_URL}/profile`, {
+        headers: { Authorization: `Bearer ${jwt}` }
       })
-
-      if (response.ok) {
-        const data = await response.json()
-        dispatch({
-          type: AUTH_ACTIONS.LOGIN_SUCCESS,
-          payload: {
-            user: data.user,
-            subscription: data.subscription
-          }
-        })
+      if (res.ok) {
+        const data = await res.json()
+        setUser(data)
       } else {
         localStorage.removeItem('auth_token')
-        dispatch({ type: AUTH_ACTIONS.SET_LOADING, payload: false })
+        setToken(null)
       }
-    } catch (error) {
-      console.error('Auth check failed:', error)
+    } catch (err) {
+      console.error('Token validation failed:', err)
       localStorage.removeItem('auth_token')
-      dispatch({ type: AUTH_ACTIONS.SET_LOADING, payload: false })
+      setToken(null)
+    } finally {
+      setLoading(false)
     }
   }
 
-  const login = async (email, password) => {
-    dispatch({ type: AUTH_ACTIONS.LOGIN_START })
-    
+  const login = async (credentials) => {
+    setLoading(true)
     try {
-        const response = await fetch(`${API_BASE_URL}/auth/login`, {
+      const res = await fetch(`${API_BASE_URL}/login`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ email, password })
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(credentials)
       })
-
-      const data = await response.json()
-
-      if (response.ok) {
+      const data = await res.json()
+      if (res.ok) {
         localStorage.setItem('auth_token', data.token)
-        dispatch({
-          type: AUTH_ACTIONS.LOGIN_SUCCESS,
-          payload: {
-            user: data.user,
-            subscription: data.subscription
-          }
-        })
+        setToken(data.token)
+        setUser(data.user)
         return { success: true }
-      } else {
-        dispatch({
-          type: AUTH_ACTIONS.LOGIN_FAILURE,
-          payload: data.message || 'Erro ao fazer login'
-        })
-        return { success: false, error: data.message }
       }
-    } catch (error) {
-      dispatch({
-        type: AUTH_ACTIONS.LOGIN_FAILURE,
-        payload: 'Erro de conexão. Tente novamente.'
-      })
+      return { success: false, error: data.message || 'Erro ao fazer login' }
+    } catch (err) {
+      console.error('Login failed:', err)
       return { success: false, error: 'Erro de conexão' }
+    } finally {
+      setLoading(false)
     }
   }
 
   const register = async (userData) => {
-    dispatch({ type: AUTH_ACTIONS.LOGIN_START })
-    
+    setLoading(true)
     try {
-        const response = await fetch(`${API_BASE_URL}/auth/register`, {
+      const res = await fetch(`${API_BASE_URL}/register`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(userData)
       })
-
-      const data = await response.json()
-
-      if (response.ok) {
+      const data = await res.json()
+      if (res.ok) {
         localStorage.setItem('auth_token', data.token)
-        dispatch({
-          type: AUTH_ACTIONS.LOGIN_SUCCESS,
-          payload: {
-            user: data.user,
-            subscription: data.subscription
-          }
-        })
+        setToken(data.token)
+        setUser(data.user)
         return { success: true }
-      } else {
-        dispatch({
-          type: AUTH_ACTIONS.LOGIN_FAILURE,
-          payload: data.message || 'Erro ao criar conta'
-        })
-        return { success: false, error: data.message }
       }
-    } catch (error) {
-      dispatch({
-        type: AUTH_ACTIONS.LOGIN_FAILURE,
-        payload: 'Erro de conexão. Tente novamente.'
-      })
+      return { success: false, error: data.message || 'Erro ao registrar' }
+    } catch (err) {
+      console.error('Register failed:', err)
       return { success: false, error: 'Erro de conexão' }
+    } finally {
+      setLoading(false)
     }
   }
 
   const logout = () => {
     localStorage.removeItem('auth_token')
-    dispatch({ type: AUTH_ACTIONS.LOGOUT })
+    setUser(null)
+    setToken(null)
   }
 
-  const updateUser = (updates) => {
-    dispatch({ type: AUTH_ACTIONS.UPDATE_USER, payload: updates })
-  }
-
-  // Helper functions
-  const hasFeature = (feature) => {
-    if (!state.subscription) return false
-    
-    const planFeatures = {
-      basic: ['property_search', 'basic_filters', 'favorites'],
-      pro: ['property_search', 'basic_filters', 'favorites', 'advanced_filters', 'market_analysis', 'alerts'],
-      premium: ['property_search', 'basic_filters', 'favorites', 'advanced_filters', 'market_analysis', 'alerts', 'ai_analysis', 'auction_strategies', 'priority_support']
+  const updateProfile = async (updates) => {
+    if (!token) return { success: false, error: 'Não autenticado' }
+    try {
+      const res = await fetch(`${API_BASE_URL}/profile`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify(updates)
+      })
+      const data = await res.json()
+      if (res.ok) {
+        setUser(data)
+        return { success: true }
+      }
+      return { success: false, error: data.message || 'Erro ao atualizar perfil' }
+    } catch (err) {
+      console.error('Update profile failed:', err)
+      return { success: false, error: 'Erro de conexão' }
     }
-    
-    const userPlan = state.subscription.plan?.name?.toLowerCase() || 'basic'
-    return planFeatures[userPlan]?.includes(feature) || false
-  }
-
-  const isAdmin = () => {
-    return state.user?.role === 'admin' || state.user?.role === 'super_admin'
-  }
-
-  const isSuperAdmin = () => {
-    return state.user?.role === 'super_admin'
-  }
-
-  const getSearchLimit = () => {
-    if (!state.subscription) return 10
-    
-    const limits = {
-      basic: 50,
-      pro: 500,
-      premium: -1 // unlimited
-    }
-    
-    const userPlan = state.subscription.plan?.name?.toLowerCase() || 'basic'
-    return limits[userPlan] || 10
   }
 
   const value = {
-    ...state,
+    user,
+    token,
+    loading,
     login,
     register,
     logout,
-    updateUser,
-    hasFeature,
-    isAdmin,
-    isSuperAdmin,
-    getSearchLimit,
-    checkAuthStatus
+    updateProfile,
+    isAuthenticated: !!user
   }
 
-  return (
-    <AuthContext.Provider value={value}>
-      {children}
-    </AuthContext.Provider>
-  )
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }
 
-// Hook to use auth context
 export function useAuth() {
   const context = useContext(AuthContext)
   if (!context) {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -110,7 +110,39 @@ const alerts = [
 ]
 
 export default function Dashboard() {
-  const { user, hasFeature, getSearchLimit } = useAuth()
+  const { user } = useAuth()
+  const hasFeature = (feature) => {
+    const planFeatures = {
+      basic: ['property_search', 'basic_filters', 'favorites'],
+      pro: [
+        'property_search',
+        'basic_filters',
+        'favorites',
+        'advanced_filters',
+        'market_analysis',
+        'alerts'
+      ],
+      premium: [
+        'property_search',
+        'basic_filters',
+        'favorites',
+        'advanced_filters',
+        'market_analysis',
+        'alerts',
+        'ai_analysis',
+        'auction_strategies',
+        'priority_support'
+      ]
+    }
+    const plan = user?.subscription?.plan?.name?.toLowerCase() || 'basic'
+    return planFeatures[plan]?.includes(feature) || false
+  }
+
+  const getSearchLimit = () => {
+    const limits = { basic: 50, pro: 500, premium: -1 }
+    const plan = user?.subscription?.plan?.name?.toLowerCase() || 'basic'
+    return limits[plan] ?? 10
+  }
   const [stats, setStats] = useState({
     totalSearches: 0,
     savedProperties: 0,


### PR DESCRIPTION
## Summary
- replace AuthContext reducer with hook-based state, JWT storage, and profile validation
- expose login/register/logout/updateProfile and isAuthenticated
- update dashboard and sidebar to compute feature access locally

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688ecc6f2f1c832a89aca49534850198