### PR TITLE
Add JWT authentication routes

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,4 @@ SQLAlchemy==2.0.41
 typing_extensions==4.14.0
 urllib3==2.5.0
 Werkzeug==3.1.3
+PyJWT==2.8.0

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -9,6 +9,7 @@ from src.models.user import db
 from src.routes.user import user_bp
 from src.routes.analysis import analysis_bp
 from src.routes.financing import financing_bp
+from src.routes.auth import auth_bp
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
 app.config['SECRET_KEY'] = 'asdf#FGSgvasgf$5$WGT'
@@ -20,6 +21,7 @@ CORS(app)
 app.register_blueprint(user_bp, url_prefix='/api')
 app.register_blueprint(analysis_bp, url_prefix='/api/analysis')
 app.register_blueprint(financing_bp, url_prefix='/api/financing')
+app.register_blueprint(auth_bp, url_prefix='/api/auth')
 
 # uncomment if you need to use database
 app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(os.path.dirname(__file__), 'database', 'app.db')}"

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -1,4 +1,5 @@
 from flask_sqlalchemy import SQLAlchemy
+from werkzeug.security import generate_password_hash, check_password_hash
 
 db = SQLAlchemy()
 
@@ -6,6 +7,15 @@ class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+
+    def set_password(self, password: str) -> None:
+        """Hash and set the user's password."""
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        """Validate a password against the stored hash."""
+        return check_password_hash(self.password_hash, password)
 
     def __repr__(self):
         return f'<User {self.username}>'

--- a/backend/src/routes/auth.py
+++ b/backend/src/routes/auth.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timedelta
+from functools import wraps
+
+import jwt
+from flask import Blueprint, current_app, jsonify, request
+
+from src.models.user import User, db
+
+auth_bp = Blueprint('auth', __name__)
+
+
+def token_required(f):
+    """Decorator that ensures a valid JWT is provided."""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token = None
+        auth_header = request.headers.get('Authorization', '')
+        if auth_header.startswith('Bearer '):
+            token = auth_header.split(' ')[1]
+        if not token:
+            return jsonify({'message': 'Token is missing'}), 401
+        try:
+            data = jwt.decode(
+                token,
+                current_app.config['SECRET_KEY'],
+                algorithms=["HS256"]
+            )
+            current_user = User.query.get(data['id'])
+            if current_user is None:
+                raise Exception('User not found')
+        except Exception:
+            return jsonify({'message': 'Token is invalid'}), 401
+        return f(current_user, *args, **kwargs)
+
+    return decorated
+
+
+@auth_bp.route('/register', methods=['POST'])
+def register():
+    data = request.get_json() or {}
+    username = data.get('username')
+    email = data.get('email')
+    password = data.get('password')
+    if not username or not email or not password:
+        return jsonify({'message': 'Missing required fields'}), 400
+    if User.query.filter((User.username == username) | (User.email == email)).first():
+        return jsonify({'message': 'User already exists'}), 400
+    user = User(username=username, email=email)
+    user.set_password(password)
+    db.session.add(user)
+    db.session.commit()
+    token = jwt.encode(
+        {'id': user.id, 'exp': datetime.utcnow() + timedelta(days=7)},
+        current_app.config['SECRET_KEY'],
+        algorithm="HS256"
+    )
+    return jsonify({'token': token, 'user': user.to_dict()}), 201
+
+
+@auth_bp.route('/login', methods=['POST'])
+def login():
+    data = request.get_json() or {}
+    email = data.get('email')
+    password = data.get('password')
+    if not email or not password:
+        return jsonify({'message': 'Missing credentials'}), 400
+    user = User.query.filter_by(email=email).first()
+    if not user or not user.check_password(password):
+        return jsonify({'message': 'Invalid credentials'}), 401
+    token = jwt.encode(
+        {'id': user.id, 'exp': datetime.utcnow() + timedelta(days=7)},
+        current_app.config['SECRET_KEY'],
+        algorithm="HS256"
+    )
+    return jsonify({'token': token, 'user': user.to_dict()})
+
+
+@auth_bp.route('/profile', methods=['GET'])
+@token_required
+def get_profile(current_user):
+    return jsonify({'user': current_user.to_dict()})
+
+
+@auth_bp.route('/profile', methods=['PUT'])
+@token_required
+def update_profile(current_user):
+    data = request.get_json() or {}
+    username = data.get('username')
+    email = data.get('email')
+    if username:
+        if User.query.filter(User.username == username, User.id != current_user.id).first():
+            return jsonify({'message': 'Username already taken'}), 400
+        current_user.username = username
+    if email:
+        if User.query.filter(User.email == email, User.id != current_user.id).first():
+            return jsonify({'message': 'Email already in use'}), 400
+        current_user.email = email
+    db.session.commit()
+    return jsonify({'user': current_user.to_dict()})
+
+
+# Optional endpoint used by frontend to validate token
+@auth_bp.route('/me', methods=['GET'])
+@token_required
+def me(current_user):
+    return jsonify({'user': current_user.to_dict()})


### PR DESCRIPTION
## Summary
- add JWT-based auth blueprint with login, register, profile endpoints and token_required decorator
- expand User model for password hashing
- register auth blueprint and add PyJWT dependency

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ecc724ea8832a9cb7a72cadd639b5