### PR TITLE
feat: update login params

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -39,13 +39,19 @@ export function AuthProvider({ children }) {
     }
   }
 
-  const login = async (credentials) => {
+  /**
+   * Realiza autenticação com as credenciais do usuário.
+   *
+   * @param {{ email: string, password: string }} params - Email e senha do usuário
+   * @returns {Promise<{ success: boolean, error?: string }>}
+   */
+  const login = async ({ email, password }) => {
     setLoading(true)
     try {
       const res = await fetch(`${API_BASE_URL}/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(credentials)
+        body: JSON.stringify({ email, password })
       })
       const data = await res.json()
       if (res.ok) {

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -47,7 +47,10 @@ const Login = () => {
     if (!validate()) return
 
     setIsLoading(true)
-    const { success, error } = await login(formData.email, formData.password)
+    const { success, error } = await login({
+      email: formData.email,
+      password: formData.password
+    })
     setIsLoading(false)
 
     if (success) {


### PR DESCRIPTION
## Summary
- switch login to use credentials object
- document login parameter format in auth context

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_688f7f0a2630832ab98bdff34618d48f