### PR TITLE
Use logout handler in token validation

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -27,13 +27,11 @@ export function AuthProvider({ children }) {
         const data = await res.json()
         setUser(data)
       } else {
-        localStorage.removeItem('auth_token')
-        setToken(null)
+        logout()
       }
     } catch (err) {
       console.error('Token validation failed:', err)
-      localStorage.removeItem('auth_token')
-      setToken(null)
+      logout()
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
## Summary
- call `logout` when token validation fails
- centralize logout logic to remove token and user state

## Testing
- `pnpm run test` (fails: Missing script: test)
- `cd backend && pytest && cd ..`

------
https://chatgpt.com/codex/tasks/task_e_688fa9724434832a95b70537185980a7