### PR TITLE
Add profile route with JWT and tests

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,4 @@ typing_extensions==4.14.0
 urllib3==2.5.0
 Werkzeug==3.1.3
 PyJWT>=2.0
+python-dotenv==1.0.1

--- a/backend/src/routes/auth.py
+++ b/backend/src/routes/auth.py
@@ -1,45 +1,116 @@
-from flask import Blueprint, request, jsonify
-from werkzeug.security import generate_password_hash, check_password_hash
-from src.models.user import db, User
+from datetime import datetime, timedelta
+from functools import wraps
+
+import jwt
+from flask import Blueprint, current_app, jsonify, request
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from src.models.user import User, db
 
 auth_bp = Blueprint('auth', __name__)
 
 
-@auth_bp.route('/auth/health', methods=['GET'])
+def _generate_token(user_id: int, expires_in: int = 3600) -> str:
+    payload = {
+        "user_id": user_id,
+        "exp": datetime.utcnow() + timedelta(seconds=expires_in),
+    }
+    return jwt.encode(payload, current_app.config["SECRET_KEY"], algorithm="HS256")
+
+
+def _token_required(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth_header = request.headers.get("Authorization", "")
+        parts = auth_header.split()
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            return jsonify({"error": "Token is missing"}), 401
+        token = parts[1]
+        try:
+            data = jwt.decode(
+                token, current_app.config["SECRET_KEY"], algorithms=["HS256"]
+            )
+            current_user = User.query.get(data.get("user_id"))
+            if not current_user:
+                raise ValueError("User not found")
+        except Exception:
+            return jsonify({"error": "Invalid or expired token"}), 401
+        return f(current_user, *args, **kwargs)
+
+    return decorated
+
+
+@auth_bp.route("/auth/health", methods=["GET"])
 def auth_health():
-    return {'status': 'ok'}
+    return {"status": "ok"}
 
 
-@auth_bp.route('/register', methods=['POST'])
+@auth_bp.route("/register", methods=["POST"])
 def register():
-    data = request.get_json()
+    data = request.get_json() or {}
 
-    if not data or not data.get('email') or not data.get('password'):
-        return jsonify({'error': 'Email and password are required'}), 400
+    email = data.get("email")
+    password = data.get("password")
+    username = data.get("username")
 
-    existing_user = User.query.filter_by(email=data['email']).first()
-    if existing_user:
-        return jsonify({'error': 'User already exists'}), 409
+    missing_fields = [
+        field for field in ["email", "password", "username"] if not data.get(field)
+    ]
+    if missing_fields:
+        return (
+            jsonify({"error": "Missing fields", "missing_fields": missing_fields}),
+            400,
+        )
 
-    hashed_password = generate_password_hash(data['password'])
-    new_user = User(email=data['email'], password=hashed_password)
+    if User.query.filter_by(email=email).first():
+        return jsonify({"error": "User already exists"}), 409
+
+    hashed_password = generate_password_hash(password)
+    new_user = User(email=email, username=username, password=hashed_password)
 
     db.session.add(new_user)
     db.session.commit()
 
-    return jsonify({'message': 'User registered successfully'}), 201
+    token = _generate_token(new_user.id)
+    return jsonify({"token": token, "user": new_user.to_dict()}), 201
 
 
-@auth_bp.route('/login', methods=['POST'])
+@auth_bp.route("/login", methods=["POST"])
 def login():
-    data = request.get_json()
+    data = request.get_json() or {}
 
-    if not data or not data.get('email') or not data.get('password'):
-        return jsonify({'error': 'Email and password are required'}), 400
+    email = data.get("email")
+    password = data.get("password")
 
-    user = User.query.filter_by(email=data['email']).first()
+    if not email or not password:
+        return jsonify({"error": "Email and password are required"}), 400
 
-    if not user or not check_password_hash(user.password, data['password']):
-        return jsonify({'error': 'Invalid credentials'}), 401
+    user = User.query.filter_by(email=email).first()
 
-    return jsonify({'message': 'Login successful'}), 200
+    if not user or not check_password_hash(user.password, password):
+        return jsonify({"error": "Invalid credentials"}), 401
+
+    token = _generate_token(user.id)
+    return jsonify({"token": token, "user": user.to_dict()}), 200
+
+
+@auth_bp.route("/profile", methods=["GET", "PUT"])
+@_token_required
+def profile(current_user):
+    if request.method == "GET":
+        return jsonify(current_user.to_dict()), 200
+
+    data = request.get_json() or {}
+    username = data.get("username")
+    email = data.get("email")
+
+    if not username and not email:
+        return jsonify({"error": "No fields to update"}), 400
+
+    if username:
+        current_user.username = username
+    if email:
+        current_user.email = email
+
+    db.session.commit()
+    return jsonify(current_user.to_dict()), 200

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -1,0 +1,62 @@
+import os
+import sys
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+# Ensure backend package is on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Configure test environment before importing app
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['SECRET_KEY'] = 'test-secret'
+
+from src.main import app  # noqa: E402
+from src.models.user import User, db  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    with app.app_context():
+        db.create_all()
+        yield app.test_client()
+        db.session.remove()
+        db.drop_all()
+
+
+def create_user(email='test@example.com', password='password', username='tester'):
+    user = User(
+        email=email,
+        username=username,
+        password=generate_password_hash(password),
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def login_and_get_token(client):
+    create_user()
+    res = client.post('/api/login', json={'email': 'test@example.com', 'password': 'password'})
+    data = res.get_json()
+    return data['token']
+
+
+def test_get_profile_returns_user(client):
+    token = login_and_get_token(client)
+    res = client.get('/api/profile', headers={'Authorization': f'Bearer {token}'})
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data['email'] == 'test@example.com'
+
+
+def test_put_profile_updates_user(client):
+    token = login_and_get_token(client)
+    res = client.put(
+        '/api/profile',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'username': 'updated'},
+    )
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data['username'] == 'updated'


### PR DESCRIPTION
## Summary
- add JWT utilities and `/profile` endpoint to auth routes for fetching and updating user data
- require username during registration and issue tokens on login/register
- add dotenv dependency and profile API tests

## Testing
- `pytest backend/tests/test_profile.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd9e9ec80832aaf6dfb256dff1b52