### PR TITLE
Use username field in registration form

### DIFF
--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -18,7 +18,7 @@ const Register = () => {
   const navigate = useNavigate()
   const { register: registerUser } = useAuth()
   const [formData, setFormData] = useState({
-    name: '',
+    username: '',
     email: '',
     password: '',
     confirmPassword: ''
@@ -37,8 +37,8 @@ const Register = () => {
 
   const validate = () => {
     const newErrors = {}
-    if (!formData.name) {
-      newErrors.name = 'Nome é obrigatório'
+    if (!formData.username) {
+      newErrors.username = 'Nome de usuário é obrigatório'
     }
     if (!formData.email) {
       newErrors.email = 'Email é obrigatório'
@@ -63,7 +63,7 @@ const Register = () => {
 
     setIsLoading(true)
     const { success, error } = await registerUser({
-      username: formData.name, // ← AQUI está a correção!
+      username: formData.username,
       email: formData.email,
       password: formData.password
     })
@@ -101,16 +101,16 @@ const Register = () => {
           )}
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="name">Nome</Label>
+              <Label htmlFor="username">Nome de usuário</Label>
               <Input
-                id="name"
-                name="name"
-                value={formData.name}
+                id="username"
+                name="username"
+                value={formData.username}
                 onChange={handleChange}
-                aria-invalid={!!errors.name}
+                aria-invalid={!!errors.username}
               />
-              {errors.name && (
-                <p className="text-sm text-destructive">{errors.name}</p>
+              {errors.username && (
+                <p className="text-sm text-destructive">{errors.username}</p>
               )}
             </div>
             <div className="space-y-2">


### PR DESCRIPTION
## Summary
- replace registration form's `name` field with `username`
- update validation and submission to send `username`
- adjust form labels and error handling for `username`

## Testing
- `pnpm run test` (fails: Missing script: test)
- `venv/bin/python -m pytest` (fails: No module named pytest)


------
https://chatgpt.com/codex/tasks/task_e_688fd9e16728832ab6ed1681299a169a