### PR TITLE
Add JWT auth with username validation

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ itsdangerous==2.2.0
 Jinja2==3.1.6
 jmespath==1.0.1
 MarkupSafe==3.0.2
+python-dotenv==1.1.1
 python-dateutil==2.9.0.post0
 s3transfer==0.13.1
 six==1.17.0

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import pytest
+
+# Ensure project root is on the PYTHONPATH
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Set environment variables before importing app
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['SECRET_KEY'] = 'test-secret'
+
+from src.main import app, db  # noqa: E402
+
+
+@pytest.fixture()
+def client():
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.create_all()
+        yield app.test_client()
+        db.session.remove()
+        db.drop_all()
+
+
+def test_register_and_login_returns_token_and_user(client):
+    payload = {
+        'username': 'testuser',
+        'email': 'test@example.com',
+        'password': 'secret'
+    }
+
+    register_resp = client.post('/api/register', json=payload)
+    assert register_resp.status_code == 201
+    reg_data = register_resp.get_json()
+    assert 'token' in reg_data
+    assert 'user' in reg_data
+    assert reg_data['user']['username'] == payload['username']
+
+    login_resp = client.post('/api/login', json=payload)
+    assert login_resp.status_code == 200
+    login_data = login_resp.get_json()
+    assert 'token' in login_data
+    assert 'user' in login_data
+    assert login_data['user']['email'] == payload['email']


### PR DESCRIPTION
## Summary
- require username on register and login
- issue JWT token and return user data
- cover new auth responses with tests

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd9cb86b8832abf2b4d2ab930cacb